### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,4 +1,6 @@
 name: SonarQube
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/micheloliveira-com/ReactiveLock/security/code-scanning/1](https://github.com/micheloliveira-com/ReactiveLock/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow primarily involves reading repository contents and using secrets for SonarQube analysis, we will set `contents: read`. This ensures that the workflow has only the permissions it needs to function correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
