### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/k6-test-checks.yml
+++ b/.github/workflows/k6-test-checks.yml
@@ -1,4 +1,6 @@
 name: k6 Test Checks
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/micheloliveira-com/ReactiveLock/security/code-scanning/9](https://github.com/micheloliveira-com/ReactiveLock/security/code-scanning/9)

To fix the problem, you should add an explicit `permissions` block to the workflow (either at the root level or at the job level), assigning only the minimum necessary permissions. In this case, since the job only downloads artifacts and processes files locally, it does not require write access to repository contents, issues, or pull requests. The canonical fix is to set `permissions: contents: read` at the top of the workflow (applies to all jobs by default), unless more specific permissions are required for a different job. This change should be made near the top of the `.github/workflows/k6-test-checks.yml` file, typically immediately after the workflow name (line 1), new line(s) added above the `on:` declaration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
