### PR TITLE
Develop feature: use-reactive-lock-package-references-flag

### DIFF
--- a/test/integration/dotnet-csharp-grpc/README.md
+++ b/test/integration/dotnet-csharp-grpc/README.md
@@ -1,0 +1,16 @@
+# ReactiveLock gRPC integration fixture
+
+This fixture runs two backend instances using peer-to-peer gRPC for ReactiveLock coordination and payment replication. Redis provides the shared work queue, while each backend keeps its replicated payment state in memory.
+
+Local builds use the ReactiveLock source projects by default. To use packed NuGet packages instead:
+
+```bash
+dotnet build src/backend/backend.csproj -p:UseReactiveLockPackageReferences=true
+```
+
+To run the complete fixture after starting the shared payment-processor network:
+
+```bash
+cd src
+docker compose up --build
+```

--- a/test/integration/dotnet-csharp-grpc/src/backend/Dockerfile
+++ b/test/integration/dotnet-csharp-grpc/src/backend/Dockerfile
@@ -29,17 +29,17 @@ WORKDIR /workspace/test/integration
 COPY ["shared/ReactiveLock.Integration.Shared/ReactiveLock.Integration.Shared.csproj", "shared/ReactiveLock.Integration.Shared/"]
 COPY ["dotnet-csharp-grpc/src/backend/backend.csproj", "dotnet-csharp-grpc/src/backend/"]
 
-RUN dotnet restore "./dotnet-csharp-grpc/src/backend/backend.csproj" -v d | tee restore.log \
+RUN dotnet restore "./dotnet-csharp-grpc/src/backend/backend.csproj" -p:UseReactiveLockPackageReferences=true -v d | tee restore.log \
     && grep -c "/src/nupkgs" restore.log | awk '{ if ($1 < 2) { print "❌ Less than 2 entries found on restore for /src/nupkgs"; exit 1 } }'
 
 COPY . .
 WORKDIR "/workspace/test/integration/dotnet-csharp-grpc/src/backend"
-RUN dotnet build "./backend.csproj" -c $BUILD_CONFIGURATION -o /app/build
+RUN dotnet build "./backend.csproj" -p:UseReactiveLockPackageReferences=true -c $BUILD_CONFIGURATION -o /app/build
 
 # This stage is used to publish the service project to be copied to the final stage
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./backend.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=true
+RUN dotnet publish "./backend.csproj" -p:UseReactiveLockPackageReferences=true -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=true
 
 # This stage is used as the base for the final stage when launching from VS to support debugging in regular mode (Default when not using the Debug configuration)
 FROM base AS aotdebug

--- a/test/integration/dotnet-csharp-grpc/src/backend/backend.csproj
+++ b/test/integration/dotnet-csharp-grpc/src/backend/backend.csproj
@@ -14,10 +14,19 @@
     <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.58" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseReactiveLockPackageReferences)' == 'true'">
     <PackageReference Include="ReactiveLock.Core" Version="*-*" />
     <PackageReference Include="ReactiveLock.DependencyInjection" Version="*-*" />
     <PackageReference Include="ReactiveLock.Distributed.Grpc" Version="*-*" />
-    <PackageReference Include="StackExchange.Redis" Version="2.8.58" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseReactiveLockPackageReferences)' != 'true'">
+    <ProjectReference Include="../../../../../src/ReactiveLock.Core/ReactiveLock.Core.csproj" />
+    <ProjectReference Include="../../../../../src/ReactiveLock.DependencyInjection/ReactiveLock.DependencyInjection.csproj" />
+    <ProjectReference Include="../../../../../src/ReactiveLock.Distributed.Grpc/ReactiveLock.Distributed.Grpc.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/integration/dotnet-csharp-mongodb/README.md
+++ b/test/integration/dotnet-csharp-mongodb/README.md
@@ -4,10 +4,10 @@ This fixture runs two backend instances using MongoDB for both ReactiveLock coor
 
 MongoDB runs as a single-node replica set because the provider uses native change streams for reactive lock propagation. The provider stores one renewable lease document per lock and application instance, backed by lookup and TTL indexes.
 
-To use source projects instead of packed NuGet packages:
+Local builds use the ReactiveLock source projects by default. To use packed NuGet packages instead:
 
 ```bash
-dotnet build src/backend/backend.csproj -p:UseLocalReactiveLockProjects=true
+dotnet build src/backend/backend.csproj -p:UseReactiveLockPackageReferences=true
 ```
 
 To run the complete fixture after starting the shared payment-processor network:

--- a/test/integration/dotnet-csharp-mongodb/src/backend/Dockerfile
+++ b/test/integration/dotnet-csharp-mongodb/src/backend/Dockerfile
@@ -13,15 +13,15 @@ ARG BUILD_CONFIGURATION=Release
 WORKDIR /workspace/test/integration
 COPY ["shared/ReactiveLock.Integration.Shared/ReactiveLock.Integration.Shared.csproj", "shared/ReactiveLock.Integration.Shared/"]
 COPY ["dotnet-csharp-mongodb/src/backend/backend.csproj", "dotnet-csharp-mongodb/src/backend/"]
-RUN dotnet restore "./dotnet-csharp-mongodb/src/backend/backend.csproj" -v d | tee restore.log \
+RUN dotnet restore "./dotnet-csharp-mongodb/src/backend/backend.csproj" -p:UseReactiveLockPackageReferences=true -v d | tee restore.log \
     && grep -c "/src/nupkgs" restore.log | awk '{ if ($1 < 2) { print "Less than 2 local packages restored"; exit 1 } }'
 COPY . .
 WORKDIR "/workspace/test/integration/dotnet-csharp-mongodb/src/backend"
-RUN dotnet build "./backend.csproj" -c $BUILD_CONFIGURATION -o /app/build
+RUN dotnet build "./backend.csproj" -p:UseReactiveLockPackageReferences=true -c $BUILD_CONFIGURATION -o /app/build
 
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./backend.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=true
+RUN dotnet publish "./backend.csproj" -p:UseReactiveLockPackageReferences=true -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=true
 
 FROM mcr.microsoft.com/dotnet/runtime-deps:10.0.2-alpine3.22 AS final
 WORKDIR /app

--- a/test/integration/dotnet-csharp-mongodb/src/backend/backend.csproj
+++ b/test/integration/dotnet-csharp-mongodb/src/backend/backend.csproj
@@ -24,13 +24,13 @@
     <TrimmerRootAssembly Include="MongoDB.Driver" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(UseLocalReactiveLockProjects)' != 'true'">
+  <ItemGroup Condition="'$(UseReactiveLockPackageReferences)' == 'true'">
     <PackageReference Include="ReactiveLock.Core" Version="*-*" />
     <PackageReference Include="ReactiveLock.DependencyInjection" Version="*-*" />
     <PackageReference Include="ReactiveLock.Distributed.MongoDB" Version="*-*" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(UseLocalReactiveLockProjects)' == 'true'">
+  <ItemGroup Condition="'$(UseReactiveLockPackageReferences)' != 'true'">
     <ProjectReference Include="../../../../../src/ReactiveLock.Core/ReactiveLock.Core.csproj" />
     <ProjectReference Include="../../../../../src/ReactiveLock.DependencyInjection/ReactiveLock.DependencyInjection.csproj" />
     <ProjectReference Include="../../../../../src/ReactiveLock.Distributed.MongoDB/ReactiveLock.Distributed.MongoDB.csproj" />

--- a/test/integration/dotnet-csharp-redis/README.md
+++ b/test/integration/dotnet-csharp-redis/README.md
@@ -1,0 +1,16 @@
+# ReactiveLock Redis integration fixture
+
+This fixture runs two backend instances using Redis for ReactiveLock coordination, the shared work queue, and payment storage.
+
+Local builds use the ReactiveLock source projects by default. To use packed NuGet packages instead:
+
+```bash
+dotnet build src/backend/backend.csproj -p:UseReactiveLockPackageReferences=true
+```
+
+To run the complete fixture after starting the shared payment-processor network:
+
+```bash
+cd src
+docker compose up --build
+```

--- a/test/integration/dotnet-csharp-redis/src/backend/Dockerfile
+++ b/test/integration/dotnet-csharp-redis/src/backend/Dockerfile
@@ -27,17 +27,17 @@ WORKDIR /workspace/test/integration
 COPY ["shared/ReactiveLock.Integration.Shared/ReactiveLock.Integration.Shared.csproj", "shared/ReactiveLock.Integration.Shared/"]
 COPY ["dotnet-csharp-redis/src/backend/backend.csproj", "dotnet-csharp-redis/src/backend/"]
 
-RUN dotnet restore "./dotnet-csharp-redis/src/backend/backend.csproj" -v d | tee restore.log \
+RUN dotnet restore "./dotnet-csharp-redis/src/backend/backend.csproj" -p:UseReactiveLockPackageReferences=true -v d | tee restore.log \
     && grep -c "/src/nupkgs" restore.log | awk '{ if ($1 < 2) { print "❌ Less than 2 entries found on restore for /src/nupkgs"; exit 1 } }'
 
 COPY . .
 WORKDIR "/workspace/test/integration/dotnet-csharp-redis/src/backend"
-RUN dotnet build "./backend.csproj" -c $BUILD_CONFIGURATION -o /app/build
+RUN dotnet build "./backend.csproj" -p:UseReactiveLockPackageReferences=true -c $BUILD_CONFIGURATION -o /app/build
 
 # This stage is used to publish the service project to be copied to the final stage
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./backend.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=true
+RUN dotnet publish "./backend.csproj" -p:UseReactiveLockPackageReferences=true -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=true
 
 # This stage is used as the base for the final stage when launching from VS to support debugging in regular mode (Default when not using the Debug configuration)
 FROM base AS aotdebug

--- a/test/integration/dotnet-csharp-redis/src/backend/backend.csproj
+++ b/test/integration/dotnet-csharp-redis/src/backend/backend.csproj
@@ -13,10 +13,19 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.58" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseReactiveLockPackageReferences)' == 'true'">
     <PackageReference Include="ReactiveLock.Core" Version="*-*" />
     <PackageReference Include="ReactiveLock.DependencyInjection" Version="*-*" />
     <PackageReference Include="ReactiveLock.Distributed.Redis" Version="*-*" />
-    <PackageReference Include="StackExchange.Redis" Version="2.8.58" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseReactiveLockPackageReferences)' != 'true'">
+    <ProjectReference Include="../../../../../src/ReactiveLock.Core/ReactiveLock.Core.csproj" />
+    <ProjectReference Include="../../../../../src/ReactiveLock.DependencyInjection/ReactiveLock.DependencyInjection.csproj" />
+    <ProjectReference Include="../../../../../src/ReactiveLock.Distributed.Redis/ReactiveLock.Distributed.Redis.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/integration/shared/ReactiveLock.Integration.Shared/ReactiveLock.Integration.Shared.csproj
+++ b/test/integration/shared/ReactiveLock.Integration.Shared/ReactiveLock.Integration.Shared.csproj
@@ -12,12 +12,12 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(UseLocalReactiveLockProjects)' != 'true'">
+  <ItemGroup Condition="'$(UseReactiveLockPackageReferences)' == 'true'">
     <PackageReference Include="ReactiveLock.Core" Version="*-*" />
     <PackageReference Include="ReactiveLock.DependencyInjection" Version="*-*" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(UseLocalReactiveLockProjects)' == 'true'">
+  <ItemGroup Condition="'$(UseReactiveLockPackageReferences)' != 'true'">
     <ProjectReference Include="../../../../src/ReactiveLock.Core/ReactiveLock.Core.csproj" />
     <ProjectReference Include="../../../../src/ReactiveLock.DependencyInjection/ReactiveLock.DependencyInjection.csproj" />
   </ItemGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added setup and usage instructions for the .NET integration fixtures.
  - Documented Docker Compose commands for running Redis, MongoDB, and gRPC scenarios.
  - Clarified that local source projects are used by default, with an option to build against packed NuGet packages.

- **Tests**
  - Improved integration fixture builds to consistently support package-based builds across restore, compilation, and publishing.
  - Added coverage for Redis-backed and peer-to-peer gRPC payment replication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->